### PR TITLE
cassini- 5950 added filepath.clean()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 	"intel/amber/tac/v1/utils"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -49,7 +50,7 @@ func LoadConfiguration() (*Configuration, error) {
 }
 
 func (c *Configuration) Save(filename string) error {
-	configFile, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	configFile, err := os.OpenFile(filepath.Clean(filename), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create config file")
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,11 +12,12 @@ import (
 	"intel/amber/tac/v1/constants"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
 func ReadAnswerFileToEnv(filename string) error {
-	fin, err := os.Open(filename)
+	fin, err := os.Open(filepath.Clean(filename))
 	if err != nil {
 		return errors.Wrap(err, "Failed to load answer file")
 	}


### PR DESCRIPTION
If you specify a filepath with a variable, there is a risk that an unintended filepath will be specified. Therefore, it is recommended to use filepath.Clean() to clean up possible bad paths, check for null bytes, new line characters and dot-dot-slash. It is always beneficial to ask where does the path come from? If you're not sure it can never have user input, it's best to sanitize the input before use AND use a known prefix/basepath.


[jira link](https://jira.devtools.intel.com/browse/CASSINI-5950)
